### PR TITLE
Use CLIG BeanCopier instead of ImmutableBean

### DIFF
--- a/src/main/java/com/codebox/bean/JavaBeanTester.java
+++ b/src/main/java/com/codebox/bean/JavaBeanTester.java
@@ -16,7 +16,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import org.junit.Assert;
-import org.mockito.cglib.beans.ImmutableBean;
+import org.mockito.cglib.beans.BeanCopier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -151,13 +151,17 @@ public final class JavaBeanTester {
 
         // Create Immutable Instance
         try {
-            @SuppressWarnings("unchecked")
-            final T e = (T) ImmutableBean.create(x);
+            BeanCopier clazzBeanCopier = BeanCopier.create(clazz, clazz, false);
+            final T e = clazz.newInstance();
+            clazzBeanCopier.copy(x, e, null);
             Assert.assertEquals(e, x);
 
-            @SuppressWarnings("unchecked")
-            final T e2 = (T) ImmutableBean.create(ext);
-            Assert.assertEquals(e2, ext);
+            if (extension != null) {
+                BeanCopier extensionBeanCopier = BeanCopier.create(extension, extension, false);
+                final E e2 = extension.newInstance();
+                extensionBeanCopier.copy(ext, e2, null);
+                Assert.assertEquals(e2, ext);
+            }
         } catch (final Exception e) {
             // Do nothing class is not mutable
         }


### PR DESCRIPTION
Using ImmutableBean generator cause issues on most equals implementation, because `source.getClass() != generated.getClass()`. 

Also, object generated by ImmutableBean is a proxy and breaks some equals/hashscode implementation that use fields instead of getter (in this case, getter is not called and field remains to `<null>` value).

It also breaks with a NPE if extension class is null.

This pull request replace ImmutableBean by BeanCopier to avoid those issues (and fix the NPE).

Thanks a lot for this work @hazendaz ! Could your perform a new release after this fork is merged ?