### PR TITLE
Add a check in the equalsHashCode test to only rerun getterSetter tes…

### DIFF
--- a/src/main/java/com/codebox/bean/JavaBeanTesterWorker.java
+++ b/src/main/java/com/codebox/bean/JavaBeanTesterWorker.java
@@ -14,25 +14,19 @@
  */
 package com.codebox.bean;
 
-import com.codebox.enums.CheckClear;
-import com.codebox.enums.CheckConstructor;
-import com.codebox.enums.CheckEquals;
-import com.codebox.enums.CheckSerialize;
-import com.codebox.enums.LoadData;
-import com.codebox.enums.LoadType;
-import com.codebox.enums.SkipStrictSerialize;
+import com.codebox.enums.*;
 import com.codebox.instance.ClassInstance;
+import lombok.Data;
+import net.sf.cglib.beans.BeanCopier;
+import org.junit.jupiter.api.Assertions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import javax.annotation.PostConstruct;
 import java.beans.IntrospectionException;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.Externalizable;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.Serializable;
+import java.io.*;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -40,16 +34,6 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
-
-import javax.annotation.PostConstruct;
-
-import lombok.Data;
-
-import net.sf.cglib.beans.BeanCopier;
-
-import org.junit.jupiter.api.Assertions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The Class JavaBeanTesterWorker.
@@ -180,14 +164,7 @@ class JavaBeanTesterWorker<T, E> {
      * @return the ter setter tests
      */
     void getterSetterTests(final T instance) {
-        PropertyDescriptor[] props;
-        try {
-            props = Introspector.getBeanInfo(this.clazz).getPropertyDescriptors();
-        } catch (final IntrospectionException e) {
-            Assertions.fail(String.format("An exception was thrown while testing class '%s': '%s'",
-                    this.clazz.getName(), e.toString()));
-            return;
-        }
+        PropertyDescriptor[] props = getProps(this.clazz);
         nextProp: for (final PropertyDescriptor prop : props) {
             // Check the list of properties that we don't want to test
             for (final String skipThis : this.skipThese) {
@@ -413,51 +390,55 @@ class JavaBeanTesterWorker<T, E> {
          */
         final E ext = new ClassInstance<E>().newInstance(this.extension);
 
-        // Test Empty Equals, HashCode, and ToString
+        // Test Equals, HashCode, and ToString
         Assertions.assertEquals(x, y);
         Assertions.assertEquals(x.hashCode(), y.hashCode());
         Assertions.assertEquals(x.toString(), y.toString());
 
-        // Test Extension Empty Equals, HashCode, and ToString
+        // Test Extension Equals, HashCode, and ToString
         Assertions.assertNotEquals(ext, y);
         Assertions.assertNotEquals(ext.hashCode(), y.hashCode());
 
-        // Test Empty One Sided Tests
+        // Test One Sided Tests
         Assertions.assertNotEquals(x, null);
         Assertions.assertEquals(x, x);
 
-        // Test Extension Empty One Sided Tests
+        // Test Extension One Sided Tests
         Assertions.assertNotEquals(ext, null);
         Assertions.assertEquals(ext, ext);
 
-        // Populate Side X
-        JavaBeanTesterWorker.load(this.clazz, x, this.loadData);
+        // If the class has setters, the previous tests would have been against empty classes
+        // If so, load the classes and retest
+        if (classHasSetters(this.clazz)){
+            // Populate Side X
+            JavaBeanTesterWorker.load(this.clazz, x, this.loadData);
 
-        // Populate Extension Side E
-        JavaBeanTesterWorker.load(this.extension, ext, this.loadData);
+            // Populate Extension Side E
+            JavaBeanTesterWorker.load(this.extension, ext, this.loadData);
 
-        // ReTest Equals (flip)
-        Assertions.assertNotEquals(y, x);
+            // ReTest Equals (flip)
+            Assertions.assertNotEquals(y, x);
 
-        // ReTest Extension Equals (flip)
-        Assertions.assertNotEquals(y, ext);
+            // ReTest Extension Equals (flip)
+            Assertions.assertNotEquals(y, ext);
 
-        // Populate Size Y
-        JavaBeanTesterWorker.load(this.clazz, y, this.loadData);
+            // Populate Size Y
+            JavaBeanTesterWorker.load(this.clazz, y, this.loadData);
 
-        // ReTest Equals and HashCode
-        if (this.loadData == LoadData.ON) {
-            Assertions.assertEquals(x, y);
-            Assertions.assertEquals(x.hashCode(), y.hashCode());
-        } else {
-            Assertions.assertNotEquals(x, y);
-            Assertions.assertNotEquals(x.hashCode(), y.hashCode());
+            // ReTest Equals and HashCode
+            if (this.loadData == LoadData.ON) {
+                Assertions.assertEquals(x, y);
+                Assertions.assertEquals(x.hashCode(), y.hashCode());
+            } else {
+                Assertions.assertNotEquals(x, y);
+                Assertions.assertNotEquals(x.hashCode(), y.hashCode());
+            }
+
+            // ReTest Extension Equals and HashCode
+            Assertions.assertNotEquals(ext, y);
+            Assertions.assertNotEquals(ext.hashCode(), y.hashCode());
+            Assertions.assertNotEquals(ext.toString(), y.toString());
         }
-
-        // ReTest Extension Equals and HashCode
-        Assertions.assertNotEquals(ext, y);
-        Assertions.assertNotEquals(ext.hashCode(), y.hashCode());
-        Assertions.assertNotEquals(ext.toString(), y.toString());
 
         // Create Immutable Instance
         try {
@@ -502,14 +483,7 @@ class JavaBeanTesterWorker<T, E> {
         final ValueBuilder valueBuilder = new ValueBuilder();
         valueBuilder.setLoadData(this.loadData);
 
-        PropertyDescriptor[] props;
-        try {
-            props = Introspector.getBeanInfo(instance.getClass()).getPropertyDescriptors();
-        } catch (final IntrospectionException e) {
-            Assertions.fail(String.format("An exception occurred during introspection of '%s': '%s'",
-                    instance.getClass().getName(), e.toString()));
-            return;
-        }
+        PropertyDescriptor[] props = getProps(instance.getClass());
         for (final PropertyDescriptor prop : props) {
             final Method getter = prop.getReadMethod();
             final Method setter = prop.getWriteMethod();
@@ -563,6 +537,20 @@ class JavaBeanTesterWorker<T, E> {
                     }
                 }
             }
+        }
+    }
+
+    private boolean classHasSetters(Class<T> clazz) {
+        return Arrays.stream(getProps(clazz)).anyMatch(propertyDescriptor -> propertyDescriptor.getWriteMethod() != null);
+    }
+
+    private PropertyDescriptor[] getProps (Class<?> clazz){
+        try {
+            return Introspector.getBeanInfo(clazz).getPropertyDescriptors();
+        } catch (final IntrospectionException e) {
+            Assertions.fail(String.format("An exception was thrown while testing class '%s': '%s'",
+                    this.clazz.getName(), e.toString()));
+            return new PropertyDescriptor[0];
         }
     }
 

--- a/src/test/java/com/codebox/bean/JavaBeanTesterTest.java
+++ b/src/test/java/com/codebox/bean/JavaBeanTesterTest.java
@@ -14,17 +14,12 @@
  */
 package com.codebox.bean;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.NotSerializableException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-
 import mockit.Deencapsulation;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.io.*;
 
 /**
  * The Class JavaBeanTesterTest.
@@ -142,6 +137,7 @@ public class JavaBeanTesterTest {
     @Test
     void test_fullBeanNullExt() {
         JavaBeanTester.builder(SampleBean.class).checkEquals().loadData().test();
+        JavaBeanTester.builder(SampleValueObject.class).checkEquals().loadData().test();
     }
 
     /**

--- a/src/test/java/com/codebox/bean/SampleValueObject.java
+++ b/src/test/java/com/codebox/bean/SampleValueObject.java
@@ -1,0 +1,56 @@
+/**
+ * JavaBean Tester (https://github.com/hazendaz/javabean-tester)
+ *
+ * Copyright (c) 2012 - 2018 Hazendaz.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of The Apache Software License,
+ * Version 2.0 which accompanies this distribution, and is available at
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Contributors:
+ *     CodeBox (Rob Dawson).
+ *     Hazendaz (Jeremy Landis).
+ */
+package com.codebox.bean;
+
+import lombok.Value;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+
+
+/*
+    From Lombok docs: https://projectlombok.org/features/Value
+    @Value is the immutable variant of @Data; 
+    all fields are made and final by default, and setters are not generated. 
+    The class itself is also made final by default, because immutability is not something that can be forced onto a subclass.
+ */
+@Value
+public class SampleValueObject {
+    EmptyBean emptyBean;
+    SampleDepthBean sampleDepthBean;
+    List<String> list;
+    Map<String, String> map;
+    ConcurrentMap<String, String> concurrentMap;
+    String string;
+    String[] stringArray;
+    Boolean booleanWrapper;
+    Integer intWrapper;
+    Long longWrapper;
+    Double doubleWrapper;
+    Float floatWrapper;
+    Character characterWrapper;
+    Byte byteWrapper;
+    Byte[] byteArray;
+    boolean booleanPrimitive;
+    int intPrimitive;
+    long longPrimitive;
+    double doublePrimitive;
+    float floatPrimitive;
+    char charPrimitive;
+    byte bytePrimitive;
+    Date date;
+}


### PR DESCRIPTION
…ts on classes with setters.  Allows for @Value annotated classes to run the check successfully.